### PR TITLE
Features/add products oid

### DIFF
--- a/YADRO-MIB.txt
+++ b/YADRO-MIB.txt
@@ -4,18 +4,21 @@ IMPORTS
     MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
     Integer32, enterprises
         FROM SNMPv2-SMI
-    TEXTUAL-CONVENTION
+    TEXTUAL-CONVENTION, TruthValue
         FROM SNMPv2-TC
     MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
         FROM SNMPv2-CONF
 ;
 
 yadro MODULE-IDENTITY
-    LAST-UPDATED    "201805110000Z"
+    LAST-UPDATED    "201806190000Z"
     ORGANIZATION    "Yadro"
     CONTACT-INFO
         "Primary Contact: SNMP support team
          email:     snmp@yadro.com"
+    DESCRIPTION
+        "Added inventory table"
+    REVISION        "201806190000Z"
     DESCRIPTION
         "Added software items table"
     REVISION        "201805110000Z"
@@ -40,7 +43,9 @@ yadroSensors            OBJECT IDENTIFIER ::= { yadro 1 }
 yadroConformance        OBJECT IDENTIFIER ::= { yadro 2 }
 yadroCompliances        OBJECT IDENTIFIER ::= { yadroConformance 1 }
 yadroGroups             OBJECT IDENTIFIER ::= { yadroConformance 2 }
+-- yadroInventoryTable takes { yadro 4 }
 -- yadroSoftwareTable takes { yadro 5 }
+
 
 --
 
@@ -631,6 +636,118 @@ yadroSoftwarePriority OBJECT-TYPE
 
 --
 
+yadroInventoryTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF YADROInventoryEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Table of inventory items."
+    ::= { yadro 4 }
+
+yadroInventoryEntry OBJECT-TYPE
+    SYNTAX      YADROInventoryEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry containing a inventory item details."
+    INDEX       { yadroInventoryPath }
+    ::= { yadroInventoryTable 1 }
+
+YADROInventoryEntry ::= SEQUENCE {
+    yadroInventoryPath          OCTET STRING,
+    yadroInventoryName          OCTET STRING,
+    yadroInventoryManufacturer  OCTET STRING,
+    yadroInventoryBuildDate     OCTET STRING,
+    yadroInventoryModel         OCTET STRING,
+    yadroInventoryPartNumber    OCTET STRING,
+    yadroInventorySerialNumber  OCTET STRING,
+    yadroInventoryVersion       OCTET STRING,
+    yadroInventoryPresent       TruthValue,
+    yadroInventoryFunctional    TruthValue
+}
+
+yadroInventoryPath OBJECT-TYPE
+    SYNTAX      OCTET STRING(SIZE(1..117))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The DBus path of the inventory item based on inventory folder."
+    ::= { yadroInventoryEntry 1 }
+
+yadroInventoryName OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The human readable name of the inventory item."
+    ::= { yadroInventoryEntry 2 }
+
+yadroInventoryManufacturer OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The inventory item manufacturer."
+    ::= { yadroInventoryEntry 3 }
+
+yadroInventoryBuildDate OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The date of inventory item manufacture in YYYYMMDD format."
+    ::= { yadroInventoryEntry 4 }
+
+yadroInventoryModel OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The model of the inventory item."
+    ::= { yadroInventoryEntry 5 }
+
+yadroInventoryPartNumber OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The inventory item part number, typically a stocking number."
+    ::= { yadroInventoryEntry 6 }
+
+yadroInventorySerialNumber OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The inventory item serial number."
+    ::= { yadroInventoryEntry 7 }
+
+yadroInventoryVersion OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The version of the inventory item."
+    ::= { yadroInventoryEntry 8 }
+
+yadroInventoryPresent OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Whether or not the inventory item is present."
+    ::= { yadroInventoryEntry 9 }
+
+yadroInventoryFunctional OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "the inventory item is functional or not."
+    ::= { yadroInventoryEntry 10 }
+
+--
+
 yadroHostPowerStateNotification NOTIFICATION-TYPE
     OBJECTS     { yadroHostPowerState }
     STATUS      current
@@ -673,6 +790,15 @@ yadroPwrSensorStateNotification NOTIFICATION-TYPE
         "Notification about changed state of current sensor"
     ::= { yadroNotifications 6 }
 
+yadroInventoryItemNotification NOTIFICATION-TYPE
+    OBJECTS     { yadroInventoryPresent,
+                  yadroInventoryFunctional }
+    STATUS      current
+    DESCRIPTION
+        "Notification about changed presence or functional
+        of the inventory item."
+    ::= { yadroNotifications 7 }
+
 --
 
 yadroCommpliance MODULE-COMPLIANCE
@@ -687,7 +813,8 @@ yadroCommpliance MODULE-COMPLIANCE
                        yadroTachSensorsTableGroup,
                        yadroCurrSensorsTableGroup,
                        yadroPowerSensorsTableGroup,
-                       yadroSoftwareTableGroup
+                       yadroSoftwareTableGroup,
+                       yadroInventoryTableGroup
                      }
     ::= { yadroCompliances 1 }
 
@@ -697,7 +824,8 @@ yadroNotificationsGroup NOTIFICATION-GROUP
                       yadroTempSensorStateNotification,
                       yadroVoltSensorStateNotification,
                       yadroCurrSensorStateNotification,
-                      yadroPwrSensorStateNotification
+                      yadroPwrSensorStateNotification,
+                      yadroInventoryItemNotification
                     }
     STATUS      current
     DESCRIPTION
@@ -792,5 +920,22 @@ yadroSoftwareTableGroup OBJECT-GROUP
         "A collection for objects providing information
         about existing software."
     ::= { yadroGroups 7 }
+
+yadroInventoryTableGroup OBJECT-GROUP
+    OBJECTS     { yadroInventoryName,
+                  yadroInventoryManufacturer,
+                  yadroInventoryBuildDate,
+                  yadroInventoryPartNumber,
+                  yadroInventorySerialNumber,
+                  yadroInventoryVersion,
+                  yadroInventoryModel,
+                  yadroInventoryPresent,
+                  yadroInventoryFunctional
+                }
+    STATUS      current
+    DESCRIPTION
+        "A collection of objects providing information
+         about existing itventory items."
+    ::= { yadroGroups 8 }
 
 END

--- a/YADRO-MIB.txt
+++ b/YADRO-MIB.txt
@@ -11,11 +11,14 @@ IMPORTS
 ;
 
 yadro MODULE-IDENTITY
-    LAST-UPDATED    "201806190000Z"
+    LAST-UPDATED    "201909260000Z"
     ORGANIZATION    "Yadro"
     CONTACT-INFO
         "Primary Contact: SNMP support team
          email:     snmp@yadro.com"
+    DESCRIPTION
+        "Added node for products manufactored by YADRO LLC"
+    REVISION        "201909260000Z"
     DESCRIPTION
         "Added inventory table"
     REVISION        "201806190000Z"
@@ -43,6 +46,7 @@ yadroSensors            OBJECT IDENTIFIER ::= { yadro 1 }
 yadroConformance        OBJECT IDENTIFIER ::= { yadro 2 }
 yadroCompliances        OBJECT IDENTIFIER ::= { yadroConformance 1 }
 yadroGroups             OBJECT IDENTIFIER ::= { yadroConformance 2 }
+yadroProducts           OBJECT IDENTIFIER ::= { yadro 3 }
 -- yadroInventoryTable takes { yadro 4 }
 -- yadroSoftwareTable takes { yadro 5 }
 

--- a/YADRO-MIB.txt
+++ b/YADRO-MIB.txt
@@ -11,11 +11,14 @@ IMPORTS
 ;
 
 yadro MODULE-IDENTITY
-    LAST-UPDATED    "201802080000Z"
+    LAST-UPDATED    "201805110000Z"
     ORGANIZATION    "Yadro"
     CONTACT-INFO
         "Primary Contact: SNMP support team
          email:     snmp@yadro.com"
+    DESCRIPTION
+        "Added software items table"
+    REVISION        "201805110000Z"
     DESCRIPTION
         "Added current and power sensor objects"
     REVISION        "201802080000Z"
@@ -37,6 +40,7 @@ yadroSensors            OBJECT IDENTIFIER ::= { yadro 1 }
 yadroConformance        OBJECT IDENTIFIER ::= { yadro 2 }
 yadroCompliances        OBJECT IDENTIFIER ::= { yadroConformance 1 }
 yadroGroups             OBJECT IDENTIFIER ::= { yadroConformance 2 }
+-- yadroSoftwareTable takes { yadro 5 }
 
 --
 
@@ -559,6 +563,73 @@ yadroPowerSensorState OBJECT-TYPE
     ::= { yadroPowerSensorsEntry 7 }
 
 --
+yadroSoftwareTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF YADROSoftwareEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Table of existing firmware images."
+    ::= { yadro 5 }
+
+yadroSoftwareEntry OBJECT-TYPE
+    SYNTAX      YADROSoftwareEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry containing a firmware images details."
+    INDEX       { yadroSoftwareHash }
+    ::= { yadroSoftwareTable 1 }
+
+YADROSoftwareEntry ::= SEQUENCE {
+    yadroSoftwareHash       OCTET STRING,
+    yadroSoftwareVersion    OCTET STRING,
+    yadroSoftwarePurpose    Integer32,
+    yadroSoftwareActivation Integer32,
+    yadroSoftwarePriority   Integer32
+}
+
+yadroSoftwareHash OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(1..8))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The software hash represent as string."
+    ::= { yadroSoftwareEntry 1 }
+
+yadroSoftwareVersion OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The software version."
+    ::= { yadroSoftwareEntry 2 }
+
+yadroSoftwarePurpose OBJECT-TYPE
+    SYNTAX      INTEGER { unknown(0), other(1), system(2), bmc(3), host(4) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The software version purpose."
+    ::= { yadroSoftwareEntry 3 }
+
+yadroSoftwareActivation OBJECT-TYPE
+    SYNTAX      INTEGER { notReady(0), invalid(1), ready(2),
+                          activating(3), active(4), failed(5) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The current activation state of the software."
+    ::= { yadroSoftwareEntry 4 }
+
+yadroSoftwarePriority OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The piority, for redundancy purposes, of the associated software."
+    ::= { yadroSoftwareEntry 5 }
+
+--
 
 yadroHostPowerStateNotification NOTIFICATION-TYPE
     OBJECTS     { yadroHostPowerState }
@@ -615,7 +686,8 @@ yadroCommpliance MODULE-COMPLIANCE
                        yadroVoltSensorsTableGroup,
                        yadroTachSensorsTableGroup,
                        yadroCurrSensorsTableGroup,
-                       yadroPowerSensorsTableGroup
+                       yadroPowerSensorsTableGroup,
+                       yadroSoftwareTableGroup
                      }
     ::= { yadroCompliances 1 }
 
@@ -708,5 +780,17 @@ yadroPowerSensorsTableGroup OBJECT-GROUP
         "A collection of objects providing information
         about power sensors."
     ::= { yadroGroups 6 }
+
+yadroSoftwareTableGroup OBJECT-GROUP
+    OBJECTS     { yadroSoftwareVersion,
+                  yadroSoftwarePurpose,
+                  yadroSoftwareActivation,
+                  yadroSoftwarePriority
+                }
+    STATUS      current
+    DESCRIPTION
+        "A collection for objects providing information
+        about existing software."
+    ::= { yadroGroups 7 }
 
 END


### PR DESCRIPTION
Adds `yadroProducts` OID as the root node for platform specific data.
Adds nodes, which are still unmoved from [yadro-snmp](https://github.com/YADRO-KNS/yadro-snmp)
